### PR TITLE
Use GetOkExists for price amounts

### DIFF
--- a/stripe/resource_stripe_price.go
+++ b/stripe/resource_stripe_price.go
@@ -206,11 +206,11 @@ func resourceStripePriceCreate(d *schema.ResourceData, m interface{}) error {
 		params.Recurring = recurringParams
 	}
 
-	if unitAmount, ok := d.GetOk("unit_amount"); ok {
+	if unitAmount, ok := d.GetOkExists("unit_amount"); ok {
 		params.UnitAmount = stripe.Int64(int64(unitAmount.(int)))
 	}
 
-	if unitAmountDecimal, ok := d.GetOk("unit_amount_decimal"); ok {
+	if unitAmountDecimal, ok := d.GetOkExists("unit_amount_decimal"); ok {
 		params.UnitAmountDecimal = stripe.Float64(unitAmountDecimal.(float64))
 	}
 


### PR DESCRIPTION
This allows for a `0` price to be set as a price `amount` in Stripe.

`GetOk` considers `0` as a null value for integers, because it's unclear whether it was intentionally set or unset.
`GetOkExists` allows us to get whatever value was set, even if it's `0`.

Fixes #42